### PR TITLE
Improve styles

### DIFF
--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -14,7 +14,7 @@
 		</header>
 		<main role="main" class="wrapper">
 			<p>This example/tutorial shows AudioChart being used with the Google Charts API; the <a href="hello-world-tutorial.html">documentation for the JavaScript behind the page explains how it works</a>.  AudioChart can also be used with HTML tables and JSON data sources.</p>
-			<div id="chart" style="width: 75vw; height: 40vw;"></div>
+			<div id="chart" class="google-chart" style="width: 75vw; height: 40vw;"></div>
 			<button id="play">Play or pause</button>
 			<p>The JavaScript code that runs this page assumes that the following elements are present.</p>
 			<pre><code>&lt;div id="chart"&gt;&lt;/div&gt;

--- a/examples/style.css
+++ b/examples/style.css
@@ -19,9 +19,9 @@ button, input, select {
 	font-size: inherit;
 }
 
-a:focus, button:focus, input:focus, select:focus, div:focus,
-a:hover, button:hover, input:hover, select:hover, div:hover {
-	outline: 4px solid yellow;
+a:focus, button:focus, input:focus, select:focus, .google-chart:focus,
+a:hover, button:hover, input:hover, select:hover, .google-chart:hover {
+	outline: 4px solid black;
 }
 
 header {


### PR DESCRIPTION
* `:focus` and `:hover` now have sufficient contrast.
* Apply `:focus` and `:hover` to only .google-chart `<div>`s.