### PR TITLE
Docco Style

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,10 @@ module.exports = function(grunt) {
 			dotGrunt: '.grunt',
 			doc: 'doc',
 			docPublic: '<%= paths.doc %>/public',
-			docInternal: '<%= paths.doc %>/internal'
+			docInternal: '<%= paths.doc %>/internal',
+			doccoCss: 'examples/hello/docco.css',
+			doccoCssWithStringsReplaced: 'examples/hello/docco.css.tmp',
+			doccoPublic: 'examples/hello/public'
 		},
 
 		clean: {
@@ -28,7 +31,8 @@ module.exports = function(grunt) {
 			testIndex: '<%= paths.test %>/index.html',
 			testCoverage: '<%= paths.testCoverage %>',
 			dotGrunt: '<%= paths.dotGrunt %>',
-			doc: '<%= paths.doc %>'
+			doc: '<%= paths.doc %>',
+			docco: '<%= paths.doccoPublic %>'
 		},
 
 		curl: {
@@ -80,8 +84,8 @@ module.exports = function(grunt) {
 					beautify: false,
 					mangle: true,
 					banner: '/* <%= pkg.name %> <%= pkg.version %> - ' +
-						'<%= grunt.template.today("yyyy-mm-dd") %> - ' +
-						'<%= pkg.license %> licence */\n',
+					'<%= grunt.template.today("yyyy-mm-dd") %> - ' +
+					'<%= pkg.license %> licence */\n',
 					sourceMap: true,
 					enclose: {
 						'window': 'exports'
@@ -89,7 +93,7 @@ module.exports = function(grunt) {
 				},
 				files: {
 					'lib/<%= pkg.name %>.min.js':
-						'<%= paths.sourceDir %>/*.js'
+					'<%= paths.sourceDir %>/*.js'
 				}
 			}
 		},
@@ -116,7 +120,39 @@ module.exports = function(grunt) {
 		docco: {
 			src: ['examples/hello/hello-world-tutorial.js'],
 			options: {
-				output: 'examples/hello/'
+				output: 'examples/hello/',
+				layout: 'classic'
+			}
+		},
+
+		'string-replace': {
+			all: {
+				files: [{
+					src: '<%= paths.doccoCss %>',
+					dest: '<%= paths.doccoCssWithStringsReplaced %>'
+				}],
+				options: {
+					replacements: [{
+						pattern: /f5f5ff/ig,
+						replacement: 'ffd'
+					}, {
+						pattern: "'Palatino Linotype', 'Book Antiqua', Palatino, FreeSerif, serif",
+						replacement: 'Verdana, sans-serif'
+					}, {
+						pattern: '#261a3b;',
+						replacement: 'auto'
+					}, {
+						pattern: '#261a3b;',
+						replacement: 'auto'
+					}]
+				}
+			}
+		},
+
+		move: {
+			'docco-css': {
+				src: '<%= paths.doccoCssWithStringsReplaced %>',
+				dest: '<%= paths.doccoCss %>'
 			}
 		},
 
@@ -135,7 +171,10 @@ module.exports = function(grunt) {
 		'jasmine',
 		'uglify',
 		'jsdoc',
-		'docco'
+		'docco',
+		'string-replace',
+		'clean:docco',
+		'move:docco-css'
 	])
 
 	// This task allows us to quickly check if there has been a new relase

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "grunt-eslint": "~19.0",
     "grunt-if-missing": "~1.0",
     "grunt-jsdoc": "~2.1",
+    "grunt-move": "~0.0",
     "grunt-open": "~0.2",
+    "grunt-string-replace": "~1.3",
     "grunt-template-jasmine-istanbul": "~0.5",
     "load-grunt-tasks": "~3.5",
     "time-grunt": "~1.4"


### PR DESCRIPTION
* Change the generated Docco CSS to make the look more closely match the
rest of the AudioChart site.
* The entire 'public' dir (containing fonts) can be ignored (and should
be, by the gh-pages branch).

This fixes #28.